### PR TITLE
Updated the app to use the 'common' tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ To use the Office 365 Ruby Connect sample, the following are required.
 2. In the [environment.rb](config/environment.rb) file do the following.
 	1. Replace *{YOUR AZURE CLIENT ID}* with the client ID of your registered Azure application.
 	2. Replace *{YOUR AZURE KEY}* with the key of your registered Azure application.
-	3. Replace *{YOUR AZURE REPLY URL}* with the reply URL of your registered Azure application. 
 3. Install the Rails application and dependencies with the following command.
 
 	```

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
   # - Client ID and client secret
   # - The resource to be accessed, in this case graph.microsoft.com
   AUTH_CTX = ADAL::AuthenticationContext.new(
-    'login.windows.net', ENV['TENANT'])
+    'login.windows.net', 'common')
   CLIENT_CRED = ADAL::ClientCredential.new(
     ENV['CLIENT_ID'],
     ENV['CLIENT_SECRET'])

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,11 +7,8 @@
 # in your Azure application.
 ENV['CLIENT_ID'] = '{YOUR AZURE CLIENT ID}'
 ENV['CLIENT_SECRET'] = '{YOUR AZURE KEY}'
-ENV['REPLY_URL'] = '{YOUR AZURE REPLY URL}'
+ENV['REPLY_URL'] = 'http://localhost:9292/auth/azureactivedirectory/callback'
 
-# This should be the domain of your test account
-# For example, contoso.onmicrosoft.com
-ENV['TENANT'] = '{YOUR DOMAIN}'
 ENV['LOGOUT_ENDPOINT'] = 'https://login.microsoftonline.com/common/oauth2/logout'
 
 # Load the Rails application.

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :azure_activedirectory, ENV['CLIENT_ID'], ENV['TENANT']
+  # Pass the id of the 'common' tenant (ed46058a-1957-405e-8d5a-fae110f41cb8)
+  provider :azure_activedirectory, ENV['CLIENT_ID'], 'ed46058a-1957-405e-8d5a-fae110f41cb8'
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,4 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   # Pass the id of the 'common' tenant (ed46058a-1957-405e-8d5a-fae110f41cb8)
-  provider :azure_activedirectory, ENV['CLIENT_ID'], 'ed46058a-1957-405e-8d5a-fae110f41cb8'
+  provider :azure_activedirectory,
+           ENV['CLIENT_ID'],
+           'ed46058a-1957-405e-8d5a-fae110f41cb8'
 end


### PR DESCRIPTION
… that developers configure their specific tenants in the environment variables.

Updated the README, we don't require developers to update the reply_url environment variable if they follow the instructions while registering their app in azure
