### PR TITLE
Updated sample to require the users domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To use the Office 365 Ruby Connect sample, the following are required.
 2. In the [environment.rb](config/environment.rb) file do the following.
 	1. Replace *ENTER_YOUR_CLIENT_ID* with the client ID of your registered Azure application.
 	2. Replace *ENTER_YOUR_SECRET* with the key of your registered Azure application.
+    2. Replace *ENTER_YOUR_DOMAIN* with your domain, in the form *your_domain.onmicrosoft.com*.
 3. Install the Rails application and dependencies with the following command.
 
 	```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To use the Office 365 Ruby Connect sample, the following are required.
 2. In the [environment.rb](config/environment.rb) file do the following.
 	1. Replace *ENTER_YOUR_CLIENT_ID* with the client ID of your registered Azure application.
 	2. Replace *ENTER_YOUR_SECRET* with the key of your registered Azure application.
-    2. Replace *ENTER_YOUR_DOMAIN* with your domain, in the form *your_domain.onmicrosoft.com*.
+    3. Replace *ENTER_YOUR_DOMAIN* with your domain, in the form *your_domain.onmicrosoft.com*.
 3. Install the Rails application and dependencies with the following command.
 
 	```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To use the Office 365 Ruby Connect sample, the following are required.
 	gem install bundler rack
 	```
 2. In the [environment.rb](config/environment.rb) file do the following.
-	1. Replace *ENTER_YOUR_CLIENT_ID* with the client ID of your registered Azure application.
-	2. Replace *ENTER_YOUR_SECRET* with the key of your registered Azure application.
-    2. Replace *ENTER_YOUR_DOMAIN* with your domain, in the form *your_domain.onmicrosoft.com*.
+    1. Replace *ENTER_YOUR_CLIENT_ID* with the client ID of your registered Azure application.
+    2. Replace *ENTER_YOUR_SECRET* with the key of your registered Azure application.
+    3. Replace *ENTER_YOUR_DOMAIN* with your domain, in the form *your_domain.onmicrosoft.com*.
 3. Install the Rails application and dependencies with the following command.
 
 	```

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,6 +7,7 @@
 # in your Azure application.
 ENV['CLIENT_ID'] = 'ENTER_YOUR_CLIENT_ID'
 ENV['CLIENT_SECRET'] = 'ENTER_YOUR_SECRET'
+ENV['DOMAIN'] = 'ENTER_YOUR_DOMAIN'
 ENV['REPLY_URL'] = 'http://localhost:3000/auth/azureactivedirectory/callback'
 
 ENV['LOGOUT_ENDPOINT'] = 'https://login.microsoftonline.com/common/oauth2/logout'

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  # Pass the id of the 'common' tenant (ed46058a-1957-405e-8d5a-fae110f41cb8)
   provider :azure_activedirectory,
            ENV['CLIENT_ID'],
-           'ed46058a-1957-405e-8d5a-fae110f41cb8'
+           ENV['DOMAIN']
 end


### PR DESCRIPTION
The omniauth library doesn't support multi-tenant web apps (see azuread/omniauth-azure-activedirectory#20), so developers have to specify a particular domain when configuring the library.
