### PR TITLE
Fixes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ Register an app on the Microsoft App Registration Portal. This generates the app
 
 2. Choose **Add an app**.
 
-3. Enter a name for the app, and choose **Create application**.
+3. Enter a name for the app, and choose **Create**.
 
 	The registration page displays, listing the properties of your app.
 
-4. Copy the application ID. This is the unique identifier for your app.
+4. Copy the `Application Id`. This is the unique identifier for your app.
 
 5. Under **Application Secrets**, choose **Generate New Password**. Copy the app secret from the **New password generated** dialog.
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,9 +15,9 @@ class PagesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   # Specifies endpoint for connecting to the Microsoft Graph
-  GRAPH_RESOURCE = 'https://graph.microsoft.com'
-  SENDMAIL_ENDPOINT = '/v1.0/me/microsoft.graph.sendmail'
-  CONTENT_TYPE = 'application/json;odata.metadata=minimal;odata.streaming=true'
+  GRAPH_RESOURCE = 'https://graph.microsoft.com'.freeze
+  SENDMAIL_ENDPOINT = '/v1.0/me/microsoft.graph.sendmail'.freeze
+  CONTENT_TYPE = 'application/json;odata.metadata=minimal;odata.streaming=true'.freeze
 
   # Delegates the browser to the v2 authentication OmniAuth module
   # which takes the user to a sign-in page, if we don't have tokens already

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,7 +5,7 @@ require_relative 'application'
 # in your Microsoft App Registration Portal entry for your app.
 ENV['CLIENT_ID'] = 'ENTER_YOUR_CLIENT_ID'
 ENV['CLIENT_SECRET'] = 'ENTER_YOUR_SECRET'
-ENV['SCOPE'] = 'openid email profile https://graph.microsoft.com/User.Read https://graph.microsoft.com/Mail.Send'
+ENV['OAUTH_SCOPE'] = 'openid email profile https://graph.microsoft.com/User.Read https://graph.microsoft.com/Mail.Send'
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/initializers/omniauth-microsoft-v2-auth.rb
+++ b/config/initializers/omniauth-microsoft-v2-auth.rb
@@ -5,5 +5,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :microsoft_v2_auth,
            ENV['CLIENT_ID'],
            ENV['CLIENT_SECRET'],
-           scope: ENV['SCOPE']
+           scope: ENV['OAUTH_SCOPE']
 end


### PR DESCRIPTION
- Rename SCOPE env var to OAUTH_SCOPE (Fixes #25)
- Freeze strings assigned to constants, in preparation for Ruby v3 (on recommendation by RuboCop)
- Minor update of README based on text changes on Microsoft App Registration Portal.